### PR TITLE
Fix typo in GH pages URL

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://iqis.github.io/rt/
+url: https://iqis.github.io/rty/
 template:
   bootstrap: 5
 


### PR DESCRIPTION
https://iqis.github.io/rt/ -> https://iqis.github.io/rty/
